### PR TITLE
g++ dependency for MPRIS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ install_dependencies() {
     # Manually install Node.js 12 since the version provided in some Ubuntu distros
     # is older than 10.13.0 which prettier requires.
     curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-    sudo apt install p7zip-full imagemagick nodejs wget
+    sudo apt install p7zip-full imagemagick nodejs wget g++ make
     sudo npm install -g electron@^6 --unsafe-perm=true
     sudo npm install -g --engine-strict asar
     sudo npm install -g prettier


### PR DESCRIPTION
MPRIS need g++ and make to compile. Linux Mint (based on Ubuntu) default installation does not have them.