### PR TITLE
Fix link out of package error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,7 @@ prepare() {
     patch --forward --strip=1 --input="$srcdir/start-hidden-on-tray.patch"
 
     cd ..
+    rm app/node_modules/abstract-socket/build/node_gyp_bins/python3
     asar pack app app.asar
 }
 


### PR DESCRIPTION
install.sh error out with:
/usr/lib/node_modules/asar/lib/filesystem.js:101
      throw new Error(`${p}: file "${link}" links out of the package`)
            ^

Error: app/node_modules/abstract-socket/build/node_gyp_bins/python3: file "../../../../../../../../usr/bin/python3.10" links out of the package
    at Filesystem.insertLink (/usr/lib/node_modules/asar/lib/filesystem.js:101:13)
    at handleFile (/usr/lib/node_modules/asar/lib/asar.js:132:20)
    at next (/usr/lib/node_modules/asar/lib/asar.js:148:11)
    at next (/usr/lib/node_modules/asar/lib/asar.js:149:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

workaround it by removing this symlink before calling "asar pack app app.asar".

The upstream issue is not fixed yet:
https://github.com/nodejs/node-gyp/issues/2713
"node_gyp_bins causes build failures in downstream packages"